### PR TITLE
Additional error trapping + error highlighting

### DIFF
--- a/Straat.xcodeproj/project.pbxproj
+++ b/Straat.xcodeproj/project.pbxproj
@@ -981,14 +981,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9T4YL57C8T;
+				DEVELOPMENT_TEAM = JVWW9HG9UE;
 				INFOPLIST_FILE = Straat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.eversun.straatinfo1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eversun.straatinfotest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Straat/lib/Straat-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1004,14 +1004,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9T4YL57C8T;
+				DEVELOPMENT_TEAM = JVWW9HG9UE;
 				INFOPLIST_FILE = Straat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.eversun.straatinfo1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eversun.straatinfotest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Straat/lib/Straat-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;

--- a/Straat/Controller/registration/RegistrationDataVC.swift
+++ b/Straat/Controller/registration/RegistrationDataVC.swift
@@ -206,9 +206,11 @@ extension RegistrationDataVC {
             case emailTxtBox:
                 debugPrint("email")
                 if textField.text?.isValidEmail() ?? false {
+                    emailTxtBox.backgroundColor = UIColor .clear
                     checkTextFieldValues()
                     debugPrint("valid email")
                 } else {
+                    emailTxtBox.backgroundColor = UIColor .red
                     emailTxtBox.becomeFirstResponder()
                     errorDesc = NSLocalizedString("wrong-input", comment: "")
                     validationDialog(vc: self, title: errorTitle, message: errorDesc, buttonText: "Ok")
@@ -220,15 +222,29 @@ extension RegistrationDataVC {
                 if textField.text?.isMobileNumberValid() ?? false {
 					let checkPrefix = textField.text?.prefix(2)
 					if checkPrefix == "06" {
+                        mobileNumberTxtBox.backgroundColor = UIColor .clear
 						checkTextFieldValues()
 					} else {
-						validationDialog(vc: self, title: errorTitle, message: "Prefix number must be 06", buttonText: "Ok")
+                        mobileNumberTxtBox.backgroundColor = UIColor .red
+                        let desc = NSLocalizedString("mobile-prefix-error", comment: "")
+						validationDialog(vc: self, title: errorTitle, message: desc, buttonText: "Ok")
+                        disableNextStepButton()
 					}
                 } else {
-                    errorDesc = NSLocalizedString("invalid-mobile-number", comment: "")
-                    validationDialog(vc: self, title: errorTitle, message: errorDesc, buttonText: "Ok")
-                    mobileNumberTxtBox.becomeFirstResponder()
-                    disableNextStepButton()
+                    mobileNumberTxtBox.backgroundColor = UIColor .red
+                    if (textField.text?.count)! < 10 {
+                        errorDesc = NSLocalizedString("invalid-mobile-number-length", comment: "")
+                        validationDialog(vc: self, title: errorTitle, message: errorDesc, buttonText: "Ok")
+                        mobileNumberTxtBox.becomeFirstResponder()
+                        disableNextStepButton()
+                    } else {
+                        errorDesc = NSLocalizedString("invalid-mobile-number", comment: "")
+                        validationDialog(vc: self, title: errorTitle, message: errorDesc, buttonText: "Ok")
+                        mobileNumberTxtBox.becomeFirstResponder()
+                        disableNextStepButton()
+                    }
+                    
+                    
 
                 }
             case passwordTxtBox:
@@ -245,6 +261,23 @@ extension RegistrationDataVC {
         default: break
         }
         
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        switch textField {
+        case mobileNumberTxtBox:
+            guard let textFieldText = textField.text,
+                let rangeOfTextToReplace = Range(range, in: textFieldText) else {
+                    return false
+            }
+            let substringToReplace = textFieldText[rangeOfTextToReplace]
+            let count = textFieldText.count - substringToReplace.count + string.count
+            return count <= 10
+        default:
+            break
+        }
+        
+         return true
     }
     
     func disableNextStepButton() {

--- a/Straat/Info.plist
+++ b/Straat/Info.plist
@@ -43,6 +43,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Straat/Resources/en.lproj/Localizable.strings
+++ b/Straat/Resources/en.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 
 "invalid-post-number" = "The postal code and/or house number entry seems to be incorrect. Please fill in the correct postal code and house number";
 
-"invalid-mobile-number" = "Your mobile number is not valid or must be 10 digits";
+"invalid-mobile-number" = "This number is not correct or already in use, please enter a different number or contact us through info@straat.info";
 
 "image-source" = "Image Source";
 
@@ -105,3 +105,7 @@
 "emergency-notification" = "Emergency Notification";
 
 "username-info-title" = "Username Info";
+
+"mobile-prefix-error" = "Prefix number must be 06";
+
+"invalid-mobile-number-length" = "Invalid mobile number length";

--- a/Straat/Resources/nl.lproj/Localizable.strings
+++ b/Straat/Resources/nl.lproj/Localizable.strings
@@ -102,3 +102,7 @@
 "emergency-notification" = "Spoedmelding";
 
 "username-info-title" = "gebruikersnaam info";
+
+"mobile-prefix-error" = "Prefix number must be 06";
+
+"invalid-mobile-number-length" = "Invalid mobile number length";

--- a/Straat/View/Base.lproj/Registration.storyboard
+++ b/Straat/View/Base.lproj/Registration.storyboard
@@ -1329,7 +1329,8 @@
         <image name="upload-img" width="192" height="192"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="CUy-Y3-mFN"/>
         <segue reference="mcr-1N-n6a"/>
-        <segue reference="gIb-xv-959"/>
+        <segue reference="NUV-xW-xjc"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
**Page F**
- Comment #1 (Mobile Number) - Fixed. Added checking of mobile number and email 
- Comment #2 (Mobile Number)- Fixed
- Comment #3 (Mobile Number) - Already existing -> "Dit nummer is niet correct of al in gebruik. Voer een ander nummer in of neem contact op via info@straat.info"
- Comment #2 & #3 (Email) - Already existing -> "Dit mailadres is al in gebruik. Voer een ander emailadres is of neem contact op via formulier op www.straat.info"
- Comment #8 - Fixed

**Page H**
- Made the background of the email textfield red if the format is not correct
- Made the background of the mobile number textfield red if the length is less than 10
- Made the background of the mobile number textfield red if the prefix is not correct
- Set the limit of the mobile number textfiled into 10 characters only 

Pending:
- To detect if a mobile number/email is already registered (backend integration needed)